### PR TITLE
Add and use dev requirements file

### DIFF
--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -4,7 +4,6 @@
 
 echo 'Python install'
 (
-   pip install pylint
+   pip install -r requirements-dev.txt
    pip install .
-  
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Dependencies, with versions explicitly declared for development and testing
+biopython==1.66
+# Packages that are not dependencies but used for building or testing
+pylint

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 from distutils.core import setup
 
 LONG_DESCRIPTION = \
-'''The program reads one or more input FASTA files. 
+'''The program reads one or more input FASTA files.
 For each file it computes a variety of statistics, and then
 prints a summary of the statistics as output.
-        
+
 The goal is to provide a solid foundation for new bioinformatics command line tools,
 and is an ideal starting place for new projects.'''
 
@@ -25,5 +25,5 @@ setup(
     license='LICENSE',
     description=('A prototypical bioinformatics command line tool'),
     long_description=(LONG_DESCRIPTION),
-    install_requires=["biopython==1.66"],
+    install_requires=["biopython"],
 )


### PR DESCRIPTION
* Created a `requirements-dev.txt` for use in development and testing
* Using this file in travis `install_dependencies.sh`
* Removed specific `biopython==1.66` dependency from setup.py. Added this pinned version to `requirements-dev.txt` instead.

`setup.py` now only requires biopython, with no version requirement. This might need changing: do we need biopython greater than some version number for any functionality used? If so we can specify `biopython > X.X` in `setup.py` instead. 

Using an absolute pinned version like `==1.66` is a bad idea in `setup.py` as it means the user can't install this package at the same time as any other package that follows similar practices.