### PR TITLE
Log timestamps in ISO8601 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ $ bionitio --log bt.log file1.fasta file2.fasta
 ```
 ```
 $ cat bt.log
-12/04/2016 19:14:47 program started
-12/04/2016 19:14:47 command line: /usr/local/bin/bionitio --log bt.log file1.fasta file2.fasta
-12/04/2016 19:14:47 Processing FASTA file from file1.fasta
-12/04/2016 19:14:47 Processing FASTA file from file2.fasta
+2016-12-04T19:14:47 program started
+2016-12-04T19:14:47 command line: /usr/local/bin/bionitio --log bt.log file1.fasta file2.fasta
+2016-12-04T19:14:47 Processing FASTA file from file1.fasta
+2016-12-04T19:14:47 Processing FASTA file from file2.fasta
 ```
 
 

--- a/bionitio/bionitio.py
+++ b/bionitio/bionitio.py
@@ -218,7 +218,7 @@ def init_logging(log_filename):
                             level=logging.DEBUG,
                             filemode='w',
                             format='%(asctime)s %(levelname)s - %(message)s',
-                            datefmt='%m-%d-%Y %H:%M:%S')
+                            datefmt="%Y-%m-%dT%H:%M:%S%z")
         logging.info('program started')
         logging.info('command line: %s', ' '.join(sys.argv))
 


### PR DESCRIPTION
Would it be sensible to follow the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard for timestamps in the log? 