### PR TITLE
Automatic deploy to PyPI / setup.py improvements

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish bionitio to PyPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Check out source-code repository
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install .
+
+      - name: Build the distribution
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish dist to PyPI
+        if: github.repository == 'BIONITIO_GITHUB_USERNAME/bionitio'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,29 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup, find_packages
 
-LONG_DESCRIPTION = \
-'''The program reads one or more input FASTA files.
-For each file it computes a variety of statistics, and then
-prints a summary of the statistics as output.
+# Remember to change when making a new release
+version = '0.1.0.0'
 
-The goal is to provide a solid foundation for new bioinformatics command line tools,
-and is an ideal starting place for new projects.'''
-
+with open("README.md") as f:
+    readme = f.read()
 
 setup(
     name='bionitio',
-    version='0.1.0.0',
+    version=version,
+    description='A prototypical bioinformatics command line tool',
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    keywords=['bionitio','bioinformatics','fasta'],
     author='BIONITIO_AUTHOR',
     author_email='BIONITIO_EMAIL',
-    packages=['bionitio'],
+    url='https://github.com/BIONITIO_GITHUB_USERNAME/bionitio',
+    license='MIT',
     package_dir={'bionitio': 'bionitio'},
     entry_points={
         'console_scripts': ['bionitio = bionitio.bionitio:main']
     },
-    url='https://github.com/BIONITIO_GITHUB_USERNAME/bionitio',
-    license='LICENSE',
-    description=('A prototypical bioinformatics command line tool'),
-    long_description=(LONG_DESCRIPTION),
     install_requires=["biopython"],
+    setup_requires=["twine>=1.11.0", "setuptools>=38.6."],
+    packages=find_packages(exclude=("readme_includes", "functional_tests")),
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     author='BIONITIO_AUTHOR',
     author_email='BIONITIO_EMAIL',
     url='https://github.com/BIONITIO_GITHUB_USERNAME/bionitio',
+    download_url = 'https://github.com/BIONITIO_GITHUB_USERNAME/bionitio/tarball/{}'.format(version),
     license='MIT',
     package_dir={'bionitio': 'bionitio'},
     entry_points={
@@ -26,4 +27,17 @@ setup(
     install_requires=["biopython"],
     setup_requires=["twine>=1.11.0", "setuptools>=38.6."],
     packages=find_packages(exclude=("readme_includes", "functional_tests")),
+    classifiers = [
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX',
+        'Operating System :: Unix',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Bio-Informatics'
+    ]
 )


### PR DESCRIPTION
Two things in this PR:

### A bit of a clean-up on `setup.py`
* Use `setuptools` instead of `distutils` (not sure if you had a specific reason to use `distutils`?)
* Use the repository readme file for the long description, specify that it's written in markdown
* Set the `licence` field to `MIT` as that is what is in the `LICENSE` file
* Use `setuptools.find_packages()` instead of manually supplying the package name(s)
* Add a few other previously missing fields

### Automated releases on [PyPI](https://pypi.org/)

A new GitHub action workflow that runs when a new GitHub release is made. It builds the dist and pushes it to PyPI automatically. Two special considerations:

* It checks the repository name, so only runs if the repo is `BIONITIO_GITHUB_USERNAME/bionitio`
  * This is to avoid trying to push releases on forks, though I'm not sure why people would make GitHub releases on their fork.
* It requires a secret called `PYPI_PASSWORD` to work
  * This must be set by the user in the GitHub repository settings. See [GitHub docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository)