### PR TITLE
Black formatter

### DIFF
--- a/.github/workflows/black-formatting.yml
+++ b/.github/workflows/black-formatting.yml
@@ -1,0 +1,17 @@
+name: Black code formatting
+on:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
+
+jobs:
+  LintBlack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check code lints with Black
+        uses: jpetrucciani/black-check@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Bionitio Contributing Guidelines
+
+Hi there! Many thanks for taking an interest in improving Bionitio.
+
+## Contribution workflow
+
+If you'd like to help out with this package, the standard workflow is as follows:
+
+1. Check that there isn't [already an issue](https://github.com/BIONITIO_GITHUB_USERNAME/bionitio/issues) about your idea to avoid duplicating work.
+    * If there isn't one already, please create one so that others know you're working on this
+2. Fork the [bionitio repository](https://github.com/BIONITIO_GITHUB_USERNAME/bionitio) to your GitHub account
+3. Make the necessary changes / additions within your forked repository
+4. Submit a Pull Request and wait for the code to be reviewed and merged.
+
+If you're not used to this workflow with git, you can start with some [basic docs from GitHub](https://help.github.com/articles/fork-a-repo/).
+
+## Installing dev requirements
+
+If you want to work with developing the Bionitio code, you'll need a couple of extra Python packages.
+These are listed in `requirements-dev.txt` and can be installed as follows:
+
+```bash
+pip install --upgrade -r requirements-dev.txt
+```
+
+Then install your local fork of Bionitio:
+
+```bash
+pip install -e .
+```
+
+## Code formatting with Black
+
+All Python code in Bionitio must be passed through the [Black Python code formatter](https://black.readthedocs.io/en/stable/).
+This ensures a harmonised code formatting style throughout the package, from all contributors.
+
+You can run Black on the command line (it's included in `requirements-dev.txt`) - eg. to run recursively on the whole repository:
+
+```bash
+black .
+```
+
+Alternatively, Black has [integrations for most common editors](https://black.readthedocs.io/en/stable/editor_integration.html)
+to automatically format code when you hit save.
+You can also set it up to run when you [make a commit](https://black.readthedocs.io/en/stable/version_control_integration.html).
+
+There is an automated CI check that runs when you open a pull-request to Bionitio that will fail if
+any code does not adhere to Black formatting.
+
+## Tests
+
+When you create a pull request with changes, [GitHub Actions](https://github.com/features/actions) will run automatic tests.
+Typically, pull-requests are only fully reviewed when these tests are passing, though of course we can help out before then.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bionitio
 
 [![travis](https://travis-ci.org/bionitio-team/bionitio-python.svg?branch=master)](https://travis-ci.org/bionitio-team/bionitio-python)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,73 @@
+# Bionitio
+
 [![travis](https://travis-ci.org/bionitio-team/bionitio-python.svg?branch=master)](https://travis-ci.org/bionitio-team/bionitio-python)
 
-# Overview 
+## Overview
 
 This program reads one or more input FASTA files. For each file it computes a variety of statistics, and then prints a summary of the statistics as output.
 
 In the examples below, `$` indicates the command line prompt.
 
-# Licence
+## Licence
 
 This program is released as open source software under the terms of [MIT License](https://raw.githubusercontent.com/bionitio-team/bionitio/master/LICENSE).
 
-# Installing
+## Installing
 
 You can install bionitio directly from the source code or build and run it from within Docker container.
 
-## Installing directly from source code
+### Installing directly from source code
 
-Clone this repository: 
-```
-$ git clone https://github.com/bionitio-team/bionitio-python
+Clone this repository:
+
+```bash
+git clone https://github.com/bionitio-team/bionitio-python
 ```
 
 Move into the repository directory:
-```
-$ cd bionitio-python
+
+```bash
+cd bionitio-python
 ```
 
 Python 3 is required for this software.
 
-Bionitio can be installed using `pip` in a variety of ways (`$` indicates the command line prompt):
+Bionitio can be installed using `pip` in a variety of ways:
 
 1. Inside a virtual environment:
-```
-$ python3 -m venv bionitio_dev
-$ source bionitio_dev/bin/activate
-$ pip install -U /path/to/bionitio
-```
+
+  ```bash
+  python3 -m venv bionitio_dev
+  source bionitio_dev/bin/activate
+  pip install -U /path/to/bionitio
+  ```
+
 2. Into the global package database for all users:
-```
-$ pip install -U /path/to/bionitio
-```
+
+  ```bash
+  pip install -U /path/to/bionitio
+  ```
+
 3. Into the user package database (for the current user only):
-```
-$ pip install -U --user /path/to/bionitio
-```
+
+  ```bash
+  pip install -U --user /path/to/bionitio
+  ```
 
 
-## Building the Docker container 
+### Building the Docker container
 
 The file `Dockerfile` contains instructions for building a Docker container for bionitio.
 
 If you have Docker installed on your computer you can build the container like so:
+
+```bash
+docker build -t bionitio .
 ```
-$ docker build -t bionitio .
-```
+
 See below for information about running bionitio within the Docker container.
 
-# General behaviour
+## General behaviour
 
 Bionitio accepts zero or more FASTA filenames on the command line. If zero filenames are specified it reads a single FASTA file from the standard input device (stdin). Otherwise it reads each named FASTA file in the order specified on the command line. Bionitio reads each input FASTA file, computes various statistics about the contents of the file, and then displays a tab-delimited summary of the statistics as output. Each input file produces at most one output line of statistics. Each line of output is prefixed by the input filename or by the text "`stdin`" if the standard input device was used.
 
@@ -74,11 +85,11 @@ These are the statistics computed by bionitio, for all sequences with length gre
 
 If there are zero sequences counted in a file, the values of MIN, AVERAGE and MAX cannot be computed. In that case bionitio will print a dash (`-`) in the place of the numerical value. Note that when `--minlen` is set to a value greater than zero it is possible that an input FASTA file does not contain any sequences with length greater-than-or-equal-to the specified value. If this situation arises bionitio acts in the same way as if there are no sequences in the file.
 
-## Help message
+### Help message
 
 Bionitio can display usage information on the command line via the `-h` or `--help` argument:
 
-```
+```console
 $ bionitio -h
 usage: bionitio [-h] [--minlen N] [--version] [--log LOG_FILE]
                   [FASTA_FILE [FASTA_FILE ...]]
@@ -95,33 +106,35 @@ optional arguments:
   --log LOG_FILE  record program progress in LOG_FILE
 ```
 
-## Reading FASTA files named on the command line
+### Reading FASTA files named on the command line
 
 Bionitio accepts zero or more named FASTA files on the command line. These must be specified following all other command line arguments. If zero files are named, bionitio will read a single FASTA file from the standard input device (stdin).
 
-There are no restrictions on the name of the FASTA files. Often FASTA filenames end in `.fa` or `.fasta`, but that is merely a convention, which is not enforced by bionitio. 
+There are no restrictions on the name of the FASTA files. Often FASTA filenames end in `.fa` or `.fasta`, but that is merely a convention, which is not enforced by bionitio.
 
 The example below illustrates bionitio applied to a single named FASTA file called `file1.fa`:
-```
+
+```console
 $ bionitio file1.fa
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 file1.fa	5264	3801855	31	722	53540
 ```
 
 The example below illustrates bionitio applied to three FASTA files called `file1.fa`, `file2.fa` and `file3.fa`:
-```
+
+```console
 $ bionitio file1.fa file2.fa file3.fa
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 file1.fa	5264	3801855	31	722	53540
 file2.fa	1245	982374	8	393	928402
-file3.fa	64	8376	102	123	212	
+file3.fa	64	8376	102	123	212
 ```
 
-## Reading a single FASTA file from standard input 
+### Reading a single FASTA file from standard input
 
 The example below illustrates bionitio reading a FASTA file from standard input. In this example we have redirected the contents of a file called `file1.fa` into the standard input using the shell redirection operator `<`:
 
-```
+```console
 $ bionitio < file1.fa
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 stdin	5264	3801855	31	722	53540
@@ -129,31 +142,30 @@ stdin	5264	3801855	31	722	53540
 
 Equivalently, you could achieve the same result by piping a FASTA file into bionitio:
 
-```
+```console
 $ cat file1.fa | bionitio
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 stdin	5264	3801855	31	722	53540
 ```
 
-## Filtering sequences by length 
+### Filtering sequences by length
 
-Bionitio provides an optional command line argument `--minlen` which causes it to ignore (not count) any sequences in the input FASTA files with length strictly less than the supplied value. 
+Bionitio provides an optional command line argument `--minlen` which causes it to ignore (not count) any sequences in the input FASTA files with length strictly less than the supplied value.
 
-The example below illustrates bionitio applied to a single FASTA file called `file`.fa` with a `--minlen` filter of 1000.
-```
+The example below illustrates bionitio applied to a single FASTA file called `file.fa` with a `--minlen` filter of 1000.
+
+```console
 $ bionitio --minlen 1000 file.fa
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 file1.fa	4711	2801855	1021	929	53540
 ```
 
-## Logging
+### Logging
 
-If the ``--log FILE`` command line argument is specified, bionitio will output a log file containing information about program progress. The log file includes the command line used to execute the program, and a note indicating which files have been processes so far. Events in the log file are annotated with their date and time of occurrence. 
+If the ``--log FILE`` command line argument is specified, bionitio will output a log file containing information about program progress. The log file includes the command line used to execute the program, and a note indicating which files have been processes so far. Events in the log file are annotated with their date and time of occurrence.
 
-```
-$ bionitio --log bt.log file1.fasta file2.fasta 
-```
-```
+```console
+$ bionitio --log bt.log file1.fasta file2.fasta
 $ cat bt.log
 2016-12-04T19:14:47 program started
 2016-12-04T19:14:47 command line: /usr/local/bin/bionitio --log bt.log file1.fasta file2.fasta
@@ -161,80 +173,93 @@ $ cat bt.log
 2016-12-04T19:14:47 Processing FASTA file from file2.fasta
 ```
 
-
-## Empty files
+### Empty files
 
 It is possible that the input FASTA file contains zero sequences, or, when the `--minlen` command line argument is used, it is possible that the file contains no sequences of length greater-than-or-equal-to the supplied value. In both of those cases bionitio will not be able to compute minimum, maximum or average sequence lengths, and instead it shows output in the following way:
 
 The example below illustrates bionitio applied to a single FASTA file called `empty.fa` which contains zero sequences:
-```
+
+```console
 $ bionitio empty.fa
 FILENAME	NUMSEQ	TOTAL	MIN	AVG	MAX
 empty.fa	0	0	-	-	-
 ```
 
-## Exit status values
+### Exit status values
 
 Bionitio returns the following exit status values:
 
-* 0: The program completed successfully.
-* 1: File I/O error. This can occur if at least one of the input FASTA files cannot be opened for reading. This can occur because the file does not exist at the specified path, or bionitio does not have permission to read from the file. 
-* 2: A command line error occurred. This can happen if the user specifies an incorrect command line argument. In this circumstance bionitio will also print a usage message to the standard error device (stderr).
+* `0`: The program completed successfully.
+* `1`: File I/O error. This can occur if at least one of the input FASTA files cannot be opened for reading. This can occur because the file does not exist at the specified path, or bionitio does not have permission to read from the file.
+* `2`: A command line error occurred. This can happen if the user specifies an incorrect command line argument. In this circumstance bionitio will also print a usage message to the standard error device (stderr).
 
-# Running within the Docker container
+## Running within the Docker container
 
-The following section describes how to run bionitio within the Docker container. It assumes you have Docker installed on your computer and have built the container as described above. 
+The following section describes how to run bionitio within the Docker container. It assumes you have Docker installed on your computer and have built the container as described above.
 The container behaves in the same way as the normal version of bionitio, however there are some Docker-specific details that you must be aware of.
 
 The general syntax for running bionitio within Docker is as follows:
+
+```bash
+docker run -i bionitio CMD
 ```
-$ docker run -i bionitio CMD
-```
-where CMD should be replaced by the specific command line invocation of bionitio. Specific examples are below.
+
+where `CMD` should be replaced by the specific command line invocation of bionitio. Specific examples are below.
 
 Display the help message:
+
+```bash
+docker run -i bionitio bionitio -h
 ```
-$ docker run -i bionitio bionitio -h
-```
+
 Note: it may seem strange that `bionitio` is mentioned twice in the command. The first instance is the name of the Docker container and the second instance is the name of the bionitio executable that you want to run inside the container.
 
 Display the version number:
-```
-$ docker run -i bionitio bionitio --version
+
+```bash
+docker run -i bionitio bionitio --version
 ```
 
 Read from a single input FASTA file redirected from standard input:
-```
-$ docker run -i bionitio bionitio < file.FASTA 
+
+```bash
+docker run -i bionitio bionitio < file.FASTA
 ```
 
-Read from multuple input FASTA files named on the command line, where all the files are in the same directory. You must replace `DATA` with the absolute file path of the directory containing the FASTA files:  
-```
-$ docker run -i -v DATA:/in bionitio bionitio /in/file1.fasta /in/file2.fasta /in/file3.fasta
-```
-The argument `DATA:/in` maps the directory called DATA on your local machine into the `/in` directory within the Docker container.
+Read from multuple input FASTA files named on the command line, where all the files are in the same directory. You must replace `DATA` with the absolute file path of the directory containing the FASTA files:
 
-Logging progress to a file in the directory OUT: 
+```bash
+docker run -i -v DATA:/in bionitio bionitio /in/file1.fasta /in/file2.fasta /in/file3.fasta
 ```
-$ docker run -i -v DATA:/in -v OUT:/out bionitio-c bionitio --log /out/logfile.txt /in/file1.fasta /in/file2.fasta /in/file3.fasta
+
+The argument `DATA:/in` maps the directory called `DATA` on your local machine into the `/in` directory within the Docker container.
+
+Logging progress to a file in the directory `OUT`:
+
+```bash
+docker run -i -v DATA:/in -v OUT:/out bionitio-c bionitio --log /out/logfile.txt /in/file1.fasta /in/file2.fasta /in/file3.fasta
 ```
+
 Replace `OUT` with the absolute path of the directory to write the log file. For example, if you want the log file written to the current working directory, replace `OUT` with `$PWD`.
+
 As above, you will also need to replace `DATA` with the absolite path to the directory containing your input FASTA files.
 
-# Testing
+## Testing
 
-## Unit tests
+### Unit tests
 
 You can run the unit tests for bionitio with the following commands:
-```
-$ cd bionitio/python/bionitio
-$ python -m unittest -v bionitio_test
+
+```bash
+cd bionitio/python/bionitio
+python -m unittest -v bionitio_test
 ```
 
-## Test suite
+### Test suite
 
 Sample test input files are provided in the `functional_tests/test_data` folder.
-```
+
+```console
 $ cd functional_tests/test_data
 $ bionitio two_sequence.fasta
 FILENAME        TOTAL   NUMSEQ  MIN     AVG     MAX
@@ -243,25 +268,26 @@ two_sequence.fasta      2       357     120     178     237
 
 Automated tests can be run using the `functional_tests/bionitio-test.sh` script like so:
 
-```
-$ cd functional_tests
-$ ./bionitio-test.sh -p bionitio -d test_data
+```bash
+cd functional_tests
+./bionitio-test.sh -p bionitio -d test_data
 ```
 
 The `-p` argument specifies the name of the program to test, the `-d` argument specifies the path of the directory containing test data.
 The script will print the number of passed and failed test cases. More detailed information about each test case can be obtained
 by requesting "verbose" output with the `-d` flag:
 
-```
-$ ./bionitio-test.sh -p bionitio -d test_data -v
+```bash
+./bionitio-test.sh -p bionitio -d test_data -v
 ```
 
 The test script can also be run inside the Docker container:
-```
-$ docker run bionitio /bionitio/functional_tests/bionitio-test.sh -p bionitio -d /bionitio/functional_tests/test_data -v
+
+```bash
+docker run bionitio /bionitio/functional_tests/bionitio-test.sh -p bionitio -d /bionitio/functional_tests/test_data -v
 ```
 
-# Common Workflow Language (CWL) wrapper
+## Common Workflow Language (CWL) wrapper
 
 The [Common Workflow Language (CWL)](https://www.commonwl.org/) specifies a portable mechanism for running software tools and workflows across many different platforms.
 We provide an example CWL wrapper for bionitio in the file `bionitio.cwl`. It invokes bionitio using the Docker container (described above). This wrapper allows you
@@ -269,12 +295,10 @@ to easily incorporate bionitio into CWL workflows, and can be executed by any CW
 
 You can test the wrapper using the `cwltool` workflow runner, which is provided by the CWL project (see the CWL documentation for how to install this on your computer).
 
+```bash
+cwltool bionitio.cwl --fasta_file file.fasta
 ```
-$ cwltool bionitio.cwl --fasta_file file.fasta 
-```
 
-# Bug reporting and feature requests
+## Bug reporting and feature requests
 
-Please submit bug reports and feature requests to the issue tracker on GitHub:
-
-[bionitio issue tracker](https://github.com/bionitio-team/bionitio/issues)
+Please submit bug reports and feature requests to the issue tracker on GitHub: [bionitio issue tracker](https://github.com/bionitio-team/bionitio/issues)

--- a/bionitio/bionitio.py
+++ b/bionitio/bionitio.py
@@ -1,4 +1,4 @@
-'''
+"""
 Module      : Main
 Description : The main entry point for the program.
 Copyright   : (c) BIONITIO_AUTHOR, BIONITIO_DATE 
@@ -8,7 +8,7 @@ Portability : POSIX
 
 The program reads one or more input FASTA files. For each file it computes a
 variety of statistics, and then prints a summary of the statistics as output.
-'''
+"""
 
 from argparse import ArgumentParser
 from math import floor
@@ -23,7 +23,7 @@ EXIT_COMMAND_LINE_ERROR = 2
 EXIT_FASTA_FILE_ERROR = 3
 DEFAULT_MIN_LEN = 0
 DEFAULT_VERBOSE = False
-HEADER = 'FILENAME\tNUMSEQ\tTOTAL\tMIN\tAVG\tMAX'
+HEADER = "FILENAME\tNUMSEQ\tTOTAL\tMIN\tAVG\tMAX"
 PROGRAM_NAME = "bionitio"
 
 
@@ -34,50 +34,41 @@ except pkg_resources.DistributionNotFound:
 
 
 def exit_with_error(message, exit_status):
-    '''Print an error message to stderr, prefixed by the program name and 'ERROR'.
+    """Print an error message to stderr, prefixed by the program name and 'ERROR'.
     Then exit program with supplied exit status.
 
     Arguments:
         message: an error message as a string.
         exit_status: a positive integer representing the exit status of the
             program.
-    '''
+    """
     logging.error(message)
     print("{} ERROR: {}, exiting".format(PROGRAM_NAME, message), file=sys.stderr)
     sys.exit(exit_status)
 
 
 def parse_args():
-    '''Parse command line arguments.
+    """Parse command line arguments.
     Returns Options object with command line argument values as attributes.
     Will exit the program on a command line error.
-    '''
-    description = 'Read one or more FASTA files, compute simple stats for each file'
+    """
+    description = "Read one or more FASTA files, compute simple stats for each file"
     parser = ArgumentParser(description=description)
     parser.add_argument(
-        '--minlen',
-        metavar='N',
+        "--minlen",
+        metavar="N",
         type=int,
         default=DEFAULT_MIN_LEN,
-        help='Minimum length sequence to include in stats (default {})'.format(
-            DEFAULT_MIN_LEN))
-    parser.add_argument('--version',
-                        action='version',
-                        version='%(prog)s ' + PROGRAM_VERSION)
-    parser.add_argument('--log',
-                        metavar='LOG_FILE',
-                        type=str,
-                        help='record program progress in LOG_FILE')
-    parser.add_argument('fasta_files',
-                        nargs='*',
-                        metavar='FASTA_FILE',
-                        type=str,
-                        help='Input FASTA files')
+        help="Minimum length sequence to include in stats (default {})".format(DEFAULT_MIN_LEN),
+    )
+    parser.add_argument("--version", action="version", version="%(prog)s " + PROGRAM_VERSION)
+    parser.add_argument("--log", metavar="LOG_FILE", type=str, help="record program progress in LOG_FILE")
+    parser.add_argument("fasta_files", nargs="*", metavar="FASTA_FILE", type=str, help="Input FASTA files")
     return parser.parse_args()
 
 
 class FastaStats(object):
-    '''Compute various statistics for a FASTA file:
+    """Compute various statistics for a FASTA file:
 
     num_seqs: the number of sequences in the file satisfying the minimum
        length requirement (minlen_threshold).
@@ -86,14 +77,10 @@ class FastaStats(object):
     max_len: the maximum length of the counted sequences.
     average: the average length of the counted sequences rounded down
        to an integer.
-    '''
-    #pylint: disable=too-many-arguments
-    def __init__(self,
-                 num_seqs=None,
-                 num_bases=None,
-                 min_len=None,
-                 max_len=None,
-                 average=None):
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, num_seqs=None, num_bases=None, min_len=None, max_len=None, average=None):
         "Build an empty FastaStats object"
         self.num_seqs = num_seqs
         self.num_bases = num_bases
@@ -109,13 +96,12 @@ class FastaStats(object):
 
     def __repr__(self):
         "Generate a printable representation of a FastaStats object"
-        return "FastaStats(num_seqs={}, num_bases={}, min_len={}, max_len={}, " \
-            "average={})".format(
-                self.num_seqs, self.num_bases, self.min_len, self.max_len,
-                self.average)
+        return "FastaStats(num_seqs={}, num_bases={}, min_len={}, max_len={}, " "average={})".format(
+            self.num_seqs, self.num_bases, self.min_len, self.max_len, self.average
+        )
 
     def from_file(self, fasta_file, minlen_threshold=DEFAULT_MIN_LEN):
-        '''Compute a FastaStats object from an input FASTA file.
+        """Compute a FastaStats object from an input FASTA file.
 
         Arguments:
            fasta_file: an open file object for the FASTA file
@@ -125,7 +111,7 @@ class FastaStats(object):
               considered in the resulting statistics.
         Result:
            A FastaStats object
-        '''
+        """
         num_seqs = num_bases = 0
         min_len = max_len = None
         for seq in SeqIO.parse(fasta_file, "fasta"):
@@ -149,7 +135,7 @@ class FastaStats(object):
         return self
 
     def pretty(self, filename):
-        '''Generate a pretty printable representation of a FastaStats object
+        """Generate a pretty printable representation of a FastaStats object
         suitable for output of the program. The output is a tab-delimited
         string containing the filename of the input FASTA file followed by
         the attributes of the object. If 0 sequences were read from the FASTA
@@ -160,7 +146,7 @@ class FastaStats(object):
            filename: the name of the input FASTA file
         Result:
            A string suitable for pretty printed output
-        '''
+        """
         if self.num_seqs > 0:
             num_seqs = str(self.num_seqs)
             num_bases = str(self.num_bases)
@@ -170,12 +156,11 @@ class FastaStats(object):
         else:
             num_seqs = num_bases = "0"
             min_len = average = max_len = "-"
-        return "\t".join([filename, num_seqs, num_bases, min_len, average,
-                          max_len])
+        return "\t".join([filename, num_seqs, num_bases, min_len, average, max_len])
 
 
 def process_files(options):
-    '''Compute and print FastaStats for each input FASTA file specified on the
+    """Compute and print FastaStats for each input FASTA file specified on the
     command line. If no FASTA files are specified on the command line then
     read from the standard input (stdin).
 
@@ -183,7 +168,7 @@ def process_files(options):
        options: the command line options of the program
     Result:
        None
-    '''
+    """
     if options.fasta_files:
         for fasta_filename in options.fasta_files:
             logging.info("Processing FASTA file from %s", fasta_filename)
@@ -202,7 +187,7 @@ def process_files(options):
 
 
 def init_logging(log_filename):
-    '''If the log_filename is defined, then
+    """If the log_filename is defined, then
     initialise the logging facility, and write log statement
     indicating the program has started, and also write out the
     command line from sys.argv
@@ -212,15 +197,17 @@ def init_logging(log_filename):
             string name of the log file to write to
     Result:
         None
-    '''
+    """
     if log_filename is not None:
-        logging.basicConfig(filename=log_filename,
-                            level=logging.DEBUG,
-                            filemode='w',
-                            format='%(asctime)s %(levelname)s - %(message)s',
-                            datefmt="%Y-%m-%dT%H:%M:%S%z")
-        logging.info('program started')
-        logging.info('command line: %s', ' '.join(sys.argv))
+        logging.basicConfig(
+            filename=log_filename,
+            level=logging.DEBUG,
+            filemode="w",
+            format="%(asctime)s %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+        logging.info("program started")
+        logging.info("command line: %s", " ".join(sys.argv))
 
 
 def main():
@@ -232,5 +219,5 @@ def main():
 
 
 # If this script is run from the command line then call the main function.
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bionitio/bionitio_test.py
+++ b/bionitio/bionitio_test.py
@@ -1,16 +1,19 @@
-'''
+"""
 Unit tests for bionitio.
 
 Usage: python -m unittest -v bionitio_test
-'''
+"""
 
 import unittest
 from io import StringIO
-#pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
 from bionitio import FastaStats
 
+
 class TestFastaStats(unittest.TestCase):
-    '''Unit tests for FastaStats'''
+    """Unit tests for FastaStats"""
+
     def do_test(self, input_str, minlen, expected):
         "Wrapper function for testing FastaStats"
         result = FastaStats().from_file(StringIO(input_str), minlen)
@@ -18,85 +21,49 @@ class TestFastaStats(unittest.TestCase):
 
     def test_zero_byte_input(self):
         "Test input containing zero bytes"
-        expected = FastaStats(num_seqs=0,
-                              num_bases=0,
-                              min_len=None,
-                              max_len=None,
-                              average=None)
-        self.do_test('', 0, expected)
+        expected = FastaStats(num_seqs=0, num_bases=0, min_len=None, max_len=None, average=None)
+        self.do_test("", 0, expected)
 
     def test_single_newline_input(self):
         "Test input containing a newline (\n) character"
-        expected = FastaStats(num_seqs=0,
-                              num_bases=0,
-                              min_len=None,
-                              max_len=None,
-                              average=None)
-        self.do_test('\n', 0, expected)
+        expected = FastaStats(num_seqs=0, num_bases=0, min_len=None, max_len=None, average=None)
+        self.do_test("\n", 0, expected)
 
     def test_single_greater_than_input(self):
         "Test input containing a single greater-than (>) character"
-        expected = FastaStats(num_seqs=1,
-                              num_bases=0,
-                              min_len=0,
-                              max_len=0,
-                              average=0)
-        self.do_test('>', 0, expected)
+        expected = FastaStats(num_seqs=1, num_bases=0, min_len=0, max_len=0, average=0)
+        self.do_test(">", 0, expected)
 
     def test_one_sequence(self):
         "Test input containing one sequence"
-        expected = FastaStats(num_seqs=1,
-                              num_bases=5,
-                              min_len=5,
-                              max_len=5,
-                              average=5)
+        expected = FastaStats(num_seqs=1, num_bases=5, min_len=5, max_len=5, average=5)
         self.do_test(">header\nATGC\nA", 0, expected)
 
     def test_two_sequences(self):
         "Test input containing two sequences"
-        expected = FastaStats(num_seqs=2,
-                              num_bases=9,
-                              min_len=2,
-                              max_len=7,
-                              average=4)
+        expected = FastaStats(num_seqs=2, num_bases=9, min_len=2, max_len=7, average=4)
         self.do_test(">header1\nATGC\nAGG\n>header2\nTT\n", 0, expected)
 
     def test_no_header(self):
         "Test input containing sequence without preceding header"
-        expected = FastaStats(num_seqs=0,
-                              num_bases=0,
-                              min_len=None,
-                              max_len=None,
-                              average=None)
+        expected = FastaStats(num_seqs=0, num_bases=0, min_len=None, max_len=None, average=None)
         self.do_test("no header\n", 0, expected)
 
     def test_minlen_less_than_all(self):
         "Test input when --minlen is less than 2 out of 2 sequences"
-        expected = FastaStats(num_seqs=2,
-                              num_bases=9,
-                              min_len=2,
-                              max_len=7,
-                              average=4)
+        expected = FastaStats(num_seqs=2, num_bases=9, min_len=2, max_len=7, average=4)
         self.do_test(">header1\nATGC\nAGG\n>header2\nTT\n", 2, expected)
 
     def test_minlen_greater_than_one(self):
         "Test input when --minlen is less than 1 out of 2 sequences"
-        expected = FastaStats(num_seqs=1,
-                              num_bases=7,
-                              min_len=7,
-                              max_len=7,
-                              average=7)
+        expected = FastaStats(num_seqs=1, num_bases=7, min_len=7, max_len=7, average=7)
         self.do_test(">header1\nATGC\nAGG\n>header2\nTT\n", 3, expected)
 
     def test_minlen_greater_than_all(self):
         "Test input when --minlen is greater than 2 out of 2 sequences"
-        expected = FastaStats(num_seqs=0,
-                              num_bases=0,
-                              min_len=None,
-                              max_len=None,
-                              average=None)
+        expected = FastaStats(num_seqs=0, num_bases=0, min_len=None, max_len=None, average=None)
         self.do_test(">header1\nATGC\nAGG\n>header2\nTT\n", 8, expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+target_version = ['py36','py37','py38']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 biopython==1.66
 # Packages that are not dependencies but used for building or testing
 pylint
+black

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,25 @@
 
 from distutils.core import setup
 
-LONG_DESCRIPTION = \
-'''The program reads one or more input FASTA files.
+LONG_DESCRIPTION = """The program reads one or more input FASTA files.
 For each file it computes a variety of statistics, and then
 prints a summary of the statistics as output.
 
 The goal is to provide a solid foundation for new bioinformatics command line tools,
-and is an ideal starting place for new projects.'''
+and is an ideal starting place for new projects."""
 
 
 setup(
-    name='bionitio',
-    version='0.1.0.0',
-    author='BIONITIO_AUTHOR',
-    author_email='BIONITIO_EMAIL',
-    packages=['bionitio'],
-    package_dir={'bionitio': 'bionitio'},
-    entry_points={
-        'console_scripts': ['bionitio = bionitio.bionitio:main']
-    },
-    url='https://github.com/BIONITIO_GITHUB_USERNAME/bionitio',
-    license='LICENSE',
-    description=('A prototypical bioinformatics command line tool'),
+    name="bionitio",
+    version="0.1.0.0",
+    author="BIONITIO_AUTHOR",
+    author_email="BIONITIO_EMAIL",
+    packages=["bionitio"],
+    package_dir={"bionitio": "bionitio"},
+    entry_points={"console_scripts": ["bionitio = bionitio.bionitio:main"]},
+    url="https://github.com/BIONITIO_GITHUB_USERNAME/bionitio",
+    license="LICENSE",
+    description=("A prototypical bioinformatics command line tool"),
     long_description=(LONG_DESCRIPTION),
     install_requires=["biopython"],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     entry_points={"console_scripts": ["bionitio = bionitio.bionitio:main"]},
     url="https://github.com/BIONITIO_GITHUB_USERNAME/bionitio",
     license="LICENSE",
-    description=("A prototypical bioinformatics command line tool"),
-    long_description=(LONG_DESCRIPTION),
+    description="A prototypical bioinformatics command line tool",
+    long_description=LONG_DESCRIPTION,
     install_requires=["biopython"],
 )


### PR DESCRIPTION
Reformatted all Python code using [Black](https://github.com/psf/black) and set up tests and documentation.

I also reformatted the main Readme quite a bit to adhere to standard Markdown syntax (eg. language specification for code colouring in code blocks, surrounding code blocks with newlines etc - it's possible to also lint markdown style if you want to go down this route, see [`markdownlint-cli`](https://www.npmjs.com/package/markdownlint-cli) and an [example GitHub Actions CI workflow](https://github.com/nf-core/tools/blob/02593c5d25d88385373af6c68503b6f17e017f03/.github/workflows/markdown-lint.yml)). You can see how this is rendered on GitHub on [my fork](https://github.com/ewels/bionitio-python/blob/black-formatter/README.md).

Closes https://github.com/bionitio-team/bionitio-python/issues/6